### PR TITLE
Update activation rule to make sip 9 and sip 10 compatible

### DIFF
--- a/sips/sip-010/sip-010-fungible-token-standard.md
+++ b/sips/sip-010/sip-010-fungible-token-standard.md
@@ -215,7 +215,7 @@ Not applicable
 
 This trait has been deployed to mainnet: [SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-10-ft-standard](https://explorer.stacks.co/txid/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-10-ft-standard?chain=mainnet)
 
-This trait will be considered activated when this trait is deployed to mainnet, and 3 different implementations of the trait have been deployed to mainnet, no later than Bitcoin block 700000.
+This trait will be considered activated when this trait is deployed to mainnet, and 3 different implementations of the trait have been deployed to mainnet,  and the transfer method in this trait contains the same error type of the response type as the transfer method of the trait of non-fungible tokens (SIP 9), no later than Bitcoin block 700000.
 
 # Reference Implementations
 


### PR DESCRIPTION
This PR
* updates the activation rule to make the error type of the transfer function in sip 9 and sip 10 compatible.

Discussions and recommendations should happen on https://github.com/clarity-lang/reference/issues/33