### PR TITLE
SIP 014 - Contract Documentation Standard

### DIFF
--- a/sips/sip-014/sip-014-clarity-doc.md
+++ b/sips/sip-014/sip-014-clarity-doc.md
@@ -1,0 +1,37 @@
+# SIP-014 | Contract Documentation Standard
+
+## Preamble
+
+SIP Number: 014
+
+Title: Standard for Smart Contract Documentation
+
+Author: @lgalabru (ludovic@galabru.com)
+
+Consideration: Technical
+
+Type: Standard
+
+Status: Draft
+
+Created: 2021-08-05
+
+License: CC0-1.0
+
+Sign-off: -
+
+## Abstract
+
+## Copyright
+
+## Introduction
+
+## Specification
+
+## Related work
+
+## Backwards compatibility
+
+## Activation
+
+## Reference Implementations


### PR DESCRIPTION
Creating this SIP as a draft to collect ideas and feedbacks.
What's our take on standardizing contract documentation?
If we were sharing a standard (a la doxygen or something), like:

```
;; @contract Counter contract 
;; @version 1

(define-fungible-token tok ...)

;; @desc increment the internal counter
;; @param a; value of the increment 
;; @post stx; will be transferred to contract
;; @post tok; will be minted for new owner
(define-public (increment (a uint))
    ...)
```

Then I think that the overall experience for users interacting with contracts could be enhanced, by explaining what will be done with args and post conditions.
Ideally, if we can converge on a convention, then the `stacks-api` could handle the mapping, and expose a documented ABI, that wallet can consume.

Thoughts?