### PR TITLE
SIP010 fix: memo clarification

### DIFF
--- a/sips/sip-010/sip-010-fungible-token-standard.md
+++ b/sips/sip-010/sip-010-fungible-token-standard.md
@@ -66,14 +66,14 @@ When returning an error in this function, the error codes should follow the same
 | u3         | `amount` is non-positive                        |
 | u4         | `sender` is not the same as `tx-sender`         |
 
-Contract implementers should take note that in Stacks 2.0, the memo field won't be included in the event emitted by successful `ft-transfer?` operations. As a consequence, if compliance with exchanges is a requirement, it is recommended to emit an event including the memo, by adding a `print` statement if the `ft-transfer?` is successful.
+Contract implementers should take note that in Stacks 2.0, the memo field won't be included in the event emitted by successful `ft-transfer?` operations. As a consequence, the implementer has to make sure that the memo is emitted by adding a `print` statement if the `ft-transfer?` is successful. The memo should be upwrapped and emitted after the `ft-transfer?` operation.
 
 Example:
 
 ```
   ...
   (try! (ft-transfer? token amount sender recipient))
-  (print memo)
+  (print (default-to 0x memo))
   ...
 ```
 

--- a/sips/sip-010/sip-010-fungible-token-standard.md
+++ b/sips/sip-010/sip-010-fungible-token-standard.md
@@ -66,14 +66,14 @@ When returning an error in this function, the error codes should follow the same
 | u3         | `amount` is non-positive                        |
 | u4         | `sender` is not the same as `tx-sender`         |
 
-Contract implementers should take note that in Stacks 2.0, the memo field won't be included in the event emitted by successful `ft-transfer?` operations. As a consequence, the implementer has to make sure that the memo is emitted by adding a `print` statement if the `ft-transfer?` is successful. The memo should be upwrapped and emitted after the `ft-transfer?` operation.
+Contract implementers should take note that in Stacks 2.0, the memo field won't be included in the event emitted by successful `ft-transfer?` operations. As a consequence, the implementer has to make sure that the memo is emitted by adding a `print` statement if the `ft-transfer?` is successful and the memo is not `none`. The memo should be upwrapped and emitted after the `ft-transfer?` operation.
 
 Example:
 
 ```
   ...
   (try! (ft-transfer? token amount sender recipient))
-  (print (default-to 0x memo))
+  (match memo to-print (print to-print) 0x)
   ...
 ```
 


### PR DESCRIPTION
An amendment to clarify how to deal with memos in `transfer`. This is based on various discussions on Discord.

The recommendation was to follow along with the `stx-bulk-transfer` tool https://github.com/blockstack/send-many-stx-cli. The relevant code:

```lisp
(define-public (send-stx-with-memo (ustx uint) (to principal) (memo (buff 34)))
 (let ((transfer-ok (try! (stx-transfer? ustx tx-sender to))))
   (print memo)
   (ok transfer-ok)))
```

From which the following was deduced:

1. The memo `print` event should come after `ft-transfer?`.
2. It should be unwrapped before being printed.
3. `print` should always be called.

It was pointed out that the order is important in order to always be able to rely on event index 1. 

Those part of the discussion would have noticed that I was already not a fan of having the optional memo be part of `transfer` in lieu of introducing a `transfer-memo`, like the upcoming STX counterpart `stx-transfer-memo?`. Nonetheless, since SIP010 is ratified we can at least clarify the language on the intended use of the `memo` parameter, as contracts in the wild are already handling it differently. (When to `print`, unwrap yes/no?) Some even completely disregard the memo field. Example: 

https://github.com/wrappedfi/tokensoft_token_stacks/blob/d3288069bbb0c4a5c45946eb363e0a9ace359222/contracts/tokensoft-token.clar#L56

Some questions & thoughts:
1. Regarding the ordering, what if a DeFi contract emits custom `print` events before calling into `transfer` with a memo? I think putting in language that implies reliance on event order is a mistake.
2. The recommendation to make the behaviour on par with the send-many tool makes the optional superfluous. The SIP might as well have just defined memo as `(buff 34)`. Should one only `print` if `(is-some memo)`? Consider:
	```
	(print (default-to 0x memo))
	;; or
	(match memo to-print (print to-print) 0x)
	```

cc @friedger @whoabuddy @LNow