### PR TITLE
SIP for Authentication Protocol

### DIFF
--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -31,9 +31,9 @@ This SIP’s copyright is held by the Stacks Open Internet Foundation.
 
 Decentralized application do not want to store credentials of their users. Instead users should be able to login using some kind of cryptographic proof that they control a public key.
 
-The private key for that public key is guarded by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. In the authenticator, the user can control which public key should be shared with the application. 
+The private key for that public key is guarded and managed by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. In the authenticator, the user can control which public key should be shared with the application. 
 
-In addition, to the public key more information can be shared like email address or profile pictures. In particular, a private key is derived by the authenticator specific for the application and for the user. This private key can be used by the application to access for example decentralized storage or sign messages in the name of the user of the application.
+In addition to the public key, more information can be shared like email address or profile pictures. In particular, a private key is derived by the authenticator specific for the application and for the user. This private key can be used by the application to access for example decentralized storage or sign messages in the name of the user of the application.
 
 # Specification
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -2,7 +2,7 @@
 
 SIP Number: X
 
-Title: Specification of Authentication Protcol
+Title: Specification of the Authentication Protcol
 
 Author: Friedger Müffke (mail@friedger.de)
 
@@ -31,7 +31,7 @@ This SIP’s copyright is held by the Stacks Open Internet Foundation.
 
 Decentralized application do not want to store credentials of their users. Instead users should be able to login using some kind of cryptographic proof that they control a public key.
 
-The private key for that public key is guarded and managed by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. In the authenticator, the user can control which public key should be shared with the application. 
+The private key for that public key is guarded and managed by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. In the authenticator, the user can control which public key should be shared with the application.
 
 In addition to the public key, more information can be shared like email address or profile pictures. In particular, a private key is derived by the authenticator specific for the application and for the user. This private key can be used by the application to access for example decentralized storage or sign messages in the name of the user of the application.
 
@@ -39,11 +39,64 @@ In addition to the public key, more information can be shared like email address
 
 ## Authentication Flow
 
-1. Application creates app transit private key, signs the auth request and sends to the authenticator.
-2. User authorizes sharing of public key in authenticator, authenticator derives app private key from app domain .
-3. Authenticator creates response and sends response to the application.
+The basic flow of the authentication between the application and the authenticator (aka wallet or agent of the user) is as follows:
+
+1. Application creates app transit private key, signs an auth request with that key and sends the request to the Authenticator.
+2. In the Authenticator, User authorizes sharing of public key, Authenticator derives app private key from request.
+3. Authenticator creates response with authorized data and sends response to the Application.
+4. Application verifies signature against the app transit private key.
 
 https://cogarius.medium.com/blockstack-world-tour-brussels-social-dapp-workshop-fb0ef887b55f
+
+## Authentication Response
+
+The authentication response is a signed JWT that contains the requests and authorized data. The token is signed with the app transit key.
+
+### Public key and BNS Username
+
+If the Stacks address representing the public key owns a BNS username, it is returned as part of the response. Other users can use the username to lookup metadata of other applications via the zonefile and the profile linked in the zonefile. The profile is signed with the private key belonging to the public key.
+
+### App key derivation
+
+### Profile
+
+### App Meta Data
+
+### Response Token Schema
+
+The response is a signed json web token following standard [RFC 7519](https://tools.ietf.org/html/rfc7519).
+
+A typical header is
+
+```
+{
+  "typ": "JWT",
+  "alg": "ES256K"
+}
+```
+
+The payload must contain the following claims:
+
+| Claim name         | Type    | Description                                                                                                                                                                                                 |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jti                | string  | As defined in RFC7519                                                                                                                                                                                       |
+| iat                | string  | As defined in RFC7519                                                                                                                                                                                       |
+| exp                | string  | As defined in RFC7519                                                                                                                                                                                       |
+| iss                | string  | Decentralized identifier defined in DID specification                                                                                                                                                       |
+| private_key        | string  | App private key for the provided domain                                                                                                                                                                     |
+| public_keys        | array   | Array of public keys owned by the user                                                                                                                                                                      |
+| profile            | object  | Object containing properties of the users, the object schema should be well-known type, like `Person` or `Organisation` defined by schema.org                                                               |
+| profile.stxAddress | object  | Object containing the user's stx address for mainnet and testnet in the form: `{mainnet: "S...", testnet: "S..."}`                                                                                          |
+| profile.apps       | object  | Deprecated; use appsMeta. Storage endpoints for user data of different apps index by app urls                                                                                                               |
+| profile.appsMeta   | object  | Information about user data of different apps. Property names are the domain name of the app. Each property value is an object of containing properties for `storage` and `publicKey`. See "App Meta Data". |
+| username           | string  | BNS username, owned by the first public key of `public_keys` claim. Can be empty string                                                                                                                     |
+| profile_url        | string  | Resolvable url of the user's profile.                                                                                                                                                                       |
+| core_token         | string? |                                                                                                                                                                                                             |
+| email              | string? | User's email address. Can be null.                                                                                                                                                                          |
+| hub_url            | string  | User's storage hub url for the current app.                                                                                                                                                                 |
+| blockstackAPIUrl   | string? | Deprecated. Url to the user's preferred authenticator                                                                                                                                                       |
+| associationToken   | string  | Signed JWT to access gaia storage bucket of user's app data.                                                                                                                                                |
+| version            | string  | Version of this schema, must be "1.3.1"                                                                                                                                                                     |
 
 ## Transport Protocol
 
@@ -51,14 +104,14 @@ The communication between application and authenticator can happen in various wa
 
 ### Stacks Provider
 
-Stacks Provider is a common interface used for web applications to communicate with the authenticator. 
+Stacks Provider is a common interface used for web applications to communicate with the authenticator.
 
-It provides functions to handle 
+It provides functions to handle
+
 1. authentication
 2. transaction signing
 
 https://github.com/hirosystems/connect/blob/main/packages/connect/src/types/provider.ts
-
 
 ### Deep Links
 
@@ -66,25 +119,13 @@ Wise app uses deep links to handle request on mobile devices
 
 ### Android Accounts
 
-Android provides an open account management system. 
+Android provides an open account management system.
 
 Example implementation: https://github.com/openintents/calendar-sync/blob/master/app/src/main/java/org/openintents/calendar/common/accounts/GenericAccountService.kt
 
-
-## Authentication Response
-
-### Public key and BNS Username
-If the Stacks address representing the public key owns a BNS username, it is returned as part of the response. Other users can use the username to lookup metadata of other applications via the zonefile and the profile linked in the zonefile. The profile is signed with the private key belonging to the public key.
-
-### App key derivation
-
-### Profile
-
-
-### Response Token
-The response is a signed JWT.
-
 # Out of Scope
+
+This SIP does not specify other flows between applications and authenticators like transaction signing or message encryption.
 
 # Backwards Compatibility
 
@@ -98,7 +139,6 @@ https://unstoppabledomains.com/blog/login-with-unstoppable
 
 https://medium.com/@sethisaab/what-is-did-auth-and-how-does-it-works-1e4884383a53
 
-
 # Implementations
 
 ## Libraries
@@ -111,10 +151,9 @@ https://github.com/PravicaInc/wise-js
 
 ## Authenticators
 
-
 ### Hiro Wallet
 
-Hiro Wallet is an wallet that handles authentication and transaction signing.
+Hiro Wallet is an browser extension that handles authentication and transaction signing.
 
 It uses a 24 mnemonic called SecretKey to derive private keys for different user accounts.
 
@@ -130,7 +169,6 @@ https://github.com/PravicaInc/Wise
 
 https://wiseapp.id
 
-
 ### Circles
 
 https://github.com/blocoio/stacks-circles-app
@@ -142,3 +180,7 @@ This SIP is activated if ..
 # Appendix A
 
 Transport protocols
+
+```
+
+```

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -20,7 +20,7 @@ Sign-off:
 
 # Abstract
 
-Decentralized application often require the authentication of their users. This SIP specifies a protocol between the application and an authenticator that results in a public key controlled by the user and a private key specific for the application for the user.
+Decentralized application often require the authentication of their users. This SIP specifies a protocol between the application and an authenticator that results in the exchange of a public key controlled by the user and a private key specific for the application for the user.
 
 # License and Copyright
 
@@ -33,7 +33,7 @@ Decentralized application do not want to store credentials of their users. Inste
 
 The private key for that public key is guarded and managed by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. The authenticator helps the user to choose a public key that should be shared with the application.
 
-In addition to the public key, more information can be shared like email address or profile pictures. Some data can be shared publicly, other only with the application. In particular, a private key is derived by the authenticator that is specific to the application and to the user. This private key can be used by the application to access for example decentralized storage or sign messages in the name of the user of the application.
+In addition to the public key, more information can be shared like email address or profile pictures. Some data can be shared publicly, other only with the application. In particular, a private key is derived by the authenticator that is specific to the application and to the user. This private key can be used by the application for example to access decentralized storage detailed in the response or sign messages in the name of the user of the application.
 
 # Specification
 
@@ -218,9 +218,8 @@ The payload must contain the following claims:
 | profile_url        | string  | Resolvable url of the public profile of the selected account.                                                                                                                                                       |
 | core_token         | string? | Usually not used. Encrypted token to access a stacks node. The public key of the app transit key must be used for encryption.                                                                                       |
 | email              | string? | User's email address. Can be null.                                                                                                                                                                                  |
-| hub_url            | string  | User's storage hub url for the current app.                                                                                                                                                                         |
-| blockstackAPIUrl   | string? | Deprecated. Url to the user's preferred authenticator                                                                                                                                                               |
-| associationToken   | string  | Signed JWT to access gaia storage of a private gaia hub.                                                                                                                                                            |
+| hub_url            | string  | User's storage hub url for the current app accessible with the app private key.                                                                                                                                                                         |
+| association_token   | string  | Signed JWT to access gaia storage of a private gaia hub.                                                                                                                                                            |
 | version            | string  | Version of this schema, must be "2.0.0"                                                                                                                                                                             |
 
 ### Verification
@@ -238,6 +237,19 @@ When the application received the authentication response it must verify that th
 
 If the authentication response contains a username the username must be owned by the issuer.
 The issuer of a JWT tokens is represented by a DID in claim `iss`. The DID has to be resolved to a public key and then the blockchain has to confirm that the username indeed is owned by the public key encoded as Stacks address.
+
+## Comparison of used JSON objects
+
+Three JSON object are specified in this document: Authentication Request, Authentication Response, Public Profile.
+
+| Property | Authentication Request           | Authentication Response   | Public Profile                                                                                                     |
+| -------- | ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Format   | JWT                    | JWT             | JSON document with property `token` with a JWT as value and property `decodedToken` with the decoded JWT as value. |
+| Issuer   | `iss`: app transit key | `iss`: data key | `issuer`: wallet key                                                                                               |
+
+The Authentication Request and Authentication Response are used for communication between authentication and application only and are called auth messages.
+
+The Public Profile can be used a [DID Document](https://www.w3.org/TR/did-core/) or a self-signed [Verifiable Credential](https://www.w3.org/TR/vc-data-model/).
 
 ## Transport Protocols
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -153,7 +153,7 @@ https://github.com/PravicaInc/wise-js
 
 ### Hiro Wallet
 
-Hiro Wallet is an browser extension that handles authentication and transaction signing.
+Hiro Wallet is a browser extension that handles authentication and transaction signing.
 
 It uses a 24 mnemonic called SecretKey to derive private keys for different user accounts.
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -72,7 +72,7 @@ The payload must contain the following claims:
 | jti                    | string | As defined in RFC7519                                                                                                                     |
 | iat                    | string | As defined in RFC7519                                                                                                                     |
 | exp                    | string | As defined in RFC7519                                                                                                                     |
-| iss                    | string | Decentralized identifier defined in DID specification representing the user's account. See Appendix C for list of well-known DID methods. |
+| iss                    | string | Decentralized identifier defined in DID specification representing the app transit public key. See Appendix C for list of well-known DID methods. |
 | public_keys            | array  | Single item list with the public key of the signer                                                                                        |
 | domain_name            | string | The url of the application with schema.                                                                                                   |
 | manifest_uri           | string | The url of the application manifest, usually domain_name + "/manifest.json"                                                               |
@@ -97,7 +97,7 @@ Authenticators should verify that the request has the following properties:
 
 ## User authorization
 
-The authenticator manages the user' private keys. The protocol requires that keys are created from a deterministic wallet using [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
+The authenticator manages the user' private keys. The protocol requires that keys are created from a deterministic wallet using [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 The authenticator can offer the user a list of accounts. Each account corresponds to a change of the key derivation path by 1. This SIP does not specify how the wallet determines which accounts should be presented. Only requirement is that one account is selected. The selected index shall be called account index `n`.
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -39,17 +39,49 @@ In addition, to the public key more information can be shared like email address
 
 ## Authentication Flow
 
-### StacksAuthenticationProvider
+1. Application creates app transit private key, signs the auth request and sends to the authenticator.
+2. User authorizes sharing of public key in authenticator, authenticator derives app private key from app domain .
+3. Authenticator creates response and sends response to the application.
 
-### Transport Protocol
+https://cogarius.medium.com/blockstack-world-tour-brussels-social-dapp-workshop-fb0ef887b55f
 
-## Authentication Result Object
+## Transport Protocol
+
+The communication between application and authenticator can happen in various ways. It is defined by the transport protocol.
+
+### Stacks Provider
+
+Stacks Provider is a common interface used for web applications to communicate with the authenticator. 
+
+It provides functions to handle 
+1. authentication
+2. transaction signing
+
+https://github.com/hirosystems/connect/blob/main/packages/connect/src/types/provider.ts
+
+
+### Deep Links
+
+Wise app uses deep links to handle request on mobile devices
+
+### Android Accounts
+
+Android provides an open account management system. 
+
+Example implementation: https://github.com/openintents/calendar-sync/blob/master/app/src/main/java/org/openintents/calendar/common/accounts/GenericAccountService.kt
+
+
+## Authentication Result
 
 ### Public key 
 
 ### App key derivation
 
 ### Profile
+
+
+### Response Token
+The response is a signed JWT.
 
 # Out of Scope
 
@@ -59,7 +91,44 @@ In addition, to the public key more information can be shared like email address
 
 ## Unstoppabledomains auth
 
+https://unstoppabledomains.com/blog/login-with-unstoppable
+
 ## DID auth
+
+https://medium.com/@sethisaab/what-is-did-auth-and-how-does-it-works-1e4884383a53
+
+
+# Implementations
+
+## Libraries
+
+https://github.com/blockstack/connect
+
+https://github.com/fungible-systems/micro-stacks
+
+## Authenticators
+
+
+### Hiro Wallet
+
+Hiro Wallet is an wallet that handles authentication and transaction signing.
+
+It uses a 24 mnemonic called SecretKey to derive private keys for different user accounts.
+
+Each account owns one private key to handle stx tokens (wallet key) and one private key to access storage (data key).
+
+The wallet key can own a BNS username.
+
+https://github.com/blockstack/stacks-wallet-web
+
+### Wise
+
+https://wiseapp.id
+
+
+### Circles
+
+https://github.com/blocoio/stacks-circles-app
 
 # Activation
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -107,6 +107,8 @@ https://github.com/blockstack/connect
 
 https://github.com/fungible-systems/micro-stacks
 
+https://github.com/PravicaInc/wise-js
+
 ## Authenticators
 
 
@@ -123,6 +125,8 @@ The wallet key can own a BNS username.
 https://github.com/blockstack/stacks-wallet-web
 
 ### Wise
+
+https://github.com/PravicaInc/Wise
 
 https://wiseapp.id
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -65,21 +65,20 @@ The authentication request is a JWT created by the application. It is signed by 
 
 The payload must contain the following claims:
 
-| Claim name             | Type   | Description                                                                                                 |
-| ---------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| jti                    | string | As defined in RFC7519                                                                                       |
-| iat                    | string | As defined in RFC7519                                                                                       |
-| exp                    | string | As defined in RFC7519                                                                                       |
-| iss                    | string | Decentralized identifier defined in DID specification representing the user's account.                      |
-|                        |
-| public_keys            | array  | Single item list with the public key of the signer                                                          |
-| domain_name            | string | The url of the application with schema.                                                                     |
-| manifest_uri           | string | The url of the application manifest, usually domain_name + "/manifest.json"                                 |
-| redirect_uri           | string | The url that should receive the authentication response                                                     |
-| do_not_include_profile | bool   |                                                                                                             |
-| supports_hub_url       | bool   |                                                                                                             |
+| Claim name             | Type   | Description                                                                                                   |
+| ---------------------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| jti                    | string | As defined in RFC7519                                                                                         |
+| iat                    | string | As defined in RFC7519                                                                                         |
+| exp                    | string | As defined in RFC7519                                                                                         |
+| iss                    | string | Decentralized identifier defined in DID specification representing the user's account.                        |
+| public_keys            | array  | Single item list with the public key of the signer                                                            |
+| domain_name            | string | The url of the application with schema.                                                                       |
+| manifest_uri           | string | The url of the application manifest, usually domain_name + "/manifest.json"                                   |
+| redirect_uri           | string | The url that should receive the authentication response                                                       |
+| do_not_include_profile | bool   |                                                                                                               |
+| supports_hub_url       | bool   |                                                                                                               |
 | scopes                 | array  | list of strings specifying the requested access to the user's account. See Appendix A for full list of scopes |
-| version                | string | must be "2.0.0"                                                                                             |
+| version                | string | must be "2.0.0"                                                                                               |
 
 ## User authorization
 
@@ -119,14 +118,14 @@ The JWT must be signed by the private key of the stacks address that ownes the u
 
 The JWT payload must have the following claims:
 
-| claim   | description                                                                                                    |
-| ------- | -------------------------------------------------------------------------------------------------------------- |
-| jti     | as defined by RFC 7519                                                                                         |
-| iat     | as defined by RFC 7519                                                                                         |
-| exp     | as defined by RFC 7519                                                                                         |
-| subject | a json object with property `publicKey` containing the hex representation of the public key of the signing key |
-| issuer  | same as subject                                                                                                |
-| claim   | a json object containing data of the username owner mixed with meta data of applications used by the owner     |
+| Claim   | Type   | Description                                                                                                    |
+| ------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| jti     | string | as defined by RFC 7519                                                                                         |
+| iat     | string | as defined by RFC 7519                                                                                         |
+| exp     | string | as defined by RFC 7519                                                                                         |
+| subject | object | a json object with property `publicKey` containing the hex representation of the public key of the signing key |
+| issuer  | object | same as subject                                                                                                |
+| claim   | object | a json object containing data of the username owner mixed with meta data of applications used by the owner     |
 
 #### Owner Data
 
@@ -202,7 +201,7 @@ The payload must contain the following claims:
 | associationToken   | string  | Signed JWT to access gaia storage of a private gaia hub.                                                                                                                                                            |
 | version            | string  | Version of this schema, must be "2.0.0"                                                                                                                                                                             |
 
-## Transport Protocol
+## Transport Protocols
 
 The communication between application and authenticator can happen in various ways. The subsections below define common transport protocols.
 
@@ -219,7 +218,7 @@ https://github.com/hirosystems/connect/blob/main/packages/connect/src/types/prov
 
 The function `authenticationRequest` expects the JWT of the authentication request as parameter and must return the authentication response as encoded JWT.
 
-This transport protocol is implemented by the [Hiro Wallet web extension](https://github.com/blockstack/stacks-wallet-web/).
+This transport protocol is implemented by the [Hiro Wallet web extension](https://github.com/blockstack/stacks-wallet-web/). Examples for client libraries are [Connect](https://github.com/blockstack/connect) and [Micro Stacks](https://github.com/fungible-systems/micro-stacks).
 
 ### HTTPS
 
@@ -235,8 +234,8 @@ On mobile devices, applications can use app links/deep links to send authenticat
 
 This transport protocol is implemented by the following authenticator apps:
 
-- [Wise app](https://github.com/PravicaInc/wise-js) and
-- [Circles app](https://github.com/blocoio/stacks-circles-app).
+- [Wise app](https://github.com/PravicaInc/wise-js) and client library[wise-js](https://github.com/PravicaInc/wise-js)
+- [Circles app](https://github.com/blocoio/stacks-circles-app) for Android.
 
 ### Android Accounts
 
@@ -246,9 +245,19 @@ The communication happens via Android Intents. The used data uris must use the q
 
 Proof of concept implementation in [OI Calendar](https://github.com/openintents/calendar-sync/blob/master/app/src/main/java/org/openintents/calendar/common/accounts/GenericAccountService.kt).
 
+## Client Libraries
+
+https://github.com/PravicaInc/wise-js
+
 # Out of Scope
 
 This SIP does not specify other communication between application and authenticator like transaction signing or message encryption.
+
+## User collections
+
+Collections are data items with well-defined schema, for example a collection of contacts (address book). Application can request access to these collection, the scope is defined as `collection._collection type_`. The Response will contain details about how to lookup collections. The collection type for scope `collection.contact` is defined in [blockstack-collections](https://github.com/blockstack/blockstack-collections).
+
+Specification of user collections is out of scope of this SIP.
 
 # Backwards Compatibility
 
@@ -256,27 +265,17 @@ The specification contains parts that are deprecated like the property `apps` in
 
 # Related Work
 
-## Unstoppabledomains auth
+## Unstoppable Login
 
-https://unstoppabledomains.com/blog/login-with-unstoppable
+Unstoppable are domain names registered on Polygon blockchain. The login is similar to the HTTPS transport protocol. When a user visits an app and logs in with their domain, the app reads the domain and directs the user to the authorization server saved to that domain name.
+
+It differs in the way how the user authorizes access to private information. The user authenticates and grants access to the information requested by signing a transaction with the key that owns their domain. The app receives an access token and an id token from the authorization server with the user’s contact information (e.g., email address).
+
+See the [blog post by unstoppabledomains](https://unstoppabledomains.com/blog/login-with-unstoppable)
 
 ## DID auth
 
-https://medium.com/@sethisaab/what-is-did-auth-and-how-does-it-works-1e4884383a53
-
-## User collections
-
-Collections are data items with well-defined schema, for example a collection of contacts (address book). Application can request access to these collection, the scope is defined as `collection._collection type_`. The Response will contain details about how to lookup collections. The collection types for scope `collection.contact` was defined in [blockstack-collections](https://github.com/blockstack/blockstack-collections).
-
-# Implementations
-
-## Libraries
-
-https://github.com/blockstack/connect
-
-https://github.com/fungible-systems/micro-stacks
-
-https://github.com/PravicaInc/wise-js
+The generalized form the authentication flow is a cryptographic challenge where users and applications use [DIDs](https://www.w3.org/TR/did-core/) and where the details about the cryptography have to be looked up via a DID resolver. See for example [this article](https://medium.com/@sethisaab/what-is-did-auth-and-how-does-it-works-1e4884383a53).
 
 # Activation
 

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -1,0 +1,70 @@
+# Preamble
+
+SIP Number: X
+
+Title: Specification of Authentication Protcol
+
+Author: Friedger Müffke (mail@friedger.de)
+
+Consideration: Technical
+
+Type: Standard
+
+Status: Draft
+
+Created: 19 November 2021
+
+License: CC0-1.0
+
+Sign-off:
+
+# Abstract
+
+Decentralized application often require the authentication of their users. This SIP specifies a protocol between the application and an authenticator that results in a public key controlled by the user and a private key specific for the application for the user.
+
+# License and Copyright
+
+This SIP is made available under the terms of the Creative Commons CC0 1.0 Universal license, available at https://creativecommons.org/publicdomain/zero/1.0/
+This SIP’s copyright is held by the Stacks Open Internet Foundation.
+
+# Introduction
+
+Decentralized application do not want to store credentials of their users. Instead users should be able to login using some kind of cryptographic proof that they control a public key.
+
+The private key for that public key is guarded by a so-called authenticator. When a users visits the app, the app needs to communicate with the authenticator. In the authenticator, the user can control which public key should be shared with the application. 
+
+In addition, to the public key more information can be shared like email address or profile pictures. In particular, a private key is derived by the authenticator specific for the application and for the user. This private key can be used by the application to access for example decentralized storage or sign messages in the name of the user of the application.
+
+# Specification
+
+## Authentication Flow
+
+### StacksAuthenticationProvider
+
+### Transport Protocol
+
+## Authentication Result Object
+
+### Public key 
+
+### App key derivation
+
+### Profile
+
+# Out of Scope
+
+# Backwards Compatibility
+
+# Related Work
+
+## Unstoppabledomains auth
+
+## DID auth
+
+# Activation
+
+This SIP is activated if ..
+
+# Appendix A
+
+Transport protocols

--- a/sips/sip-x/sip-x-authentication-protocol.md
+++ b/sips/sip-x/sip-x-authentication-protocol.md
@@ -71,9 +71,10 @@ Android provides an open account management system.
 Example implementation: https://github.com/openintents/calendar-sync/blob/master/app/src/main/java/org/openintents/calendar/common/accounts/GenericAccountService.kt
 
 
-## Authentication Result
+## Authentication Response
 
-### Public key 
+### Public key and BNS Username
+If the Stacks address representing the public key owns a BNS username, it is returned as part of the response. Other users can use the username to lookup metadata of other applications via the zonefile and the profile linked in the zonefile. The profile is signed with the private key belonging to the public key.
 
 ### App key derivation
 


### PR DESCRIPTION
This SIP defines a authentication protocol used by Stacks apps.

The current version has (hopefully) all the required information about the protocol as it is currently used. 

I changed three properties of the auth response: `hubUrl` -> `hub_url` and `associationToken` -> `association_token`. `profile.stxAddress`-> `stx_address`.

I added `state` to the auth messages as defined in OAuth 2.0.

It is recommended to use  `did:stacks:v2` instead of `did:btc-addr`

For the public profile, this spec uses the Verifiable Credential model. The [VC spec](https://www.w3.org/TR/vc-data-model) was chosen because it now has W3C Recommendation status.