### PR TITLE
Update CAB configuration

### DIFF
--- a/considerations/README.md
+++ b/considerations/README.md
@@ -1,9 +1,7 @@
-## Consideration Advisory Boards
+# Consideration Advisory Boards
 
-This directory lists the contact information for all existing consideration
-advisory boards.  Per SIP-000, these boards vote to advance a SIP from Accepted
-status to Recommended status once it has been reviewed by the board's domain
-experts.
+This directory lists the contact information, members, and other details for the Consideration Advisory Boards (CABs) that are part of the Stacks Improvement Proposal (SIP) process.
 
-If you are interested in joining one or more of these boards, please reach out
-to the chairperson.
+Per [SIP-000](../sips/sip-000/sip-000-stacks-improvement-proposal-process.md), these boards vote to advance a SIP from Accepted to Recommended status once it has been reviewed by the board's domain experts.
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/TEMPLATE.md
+++ b/considerations/TEMPLATE.md
@@ -1,0 +1,79 @@
+# Consideration Advisory Board Template
+
+The template below serves as a starting point for creating a new CAB or updating existing details.
+
+**Inactive CAB**
+
+If a CAB is not active yet, it will have only two sections:
+
+- the main section describing the members
+- an about section explaining the placeholder status
+- example: [Diversity CAB](diversity.md)
+
+**Active CAB**
+
+If a CAB is active, it starts with the member information section, directly below the CAB title.
+
+---
+
+Chairperson: Name
+
+Members:
+
+- Name 1 <email>
+- Name 2 <email>
+- Name 3 <email>
+
+Discussions-to: https://github.com/stacksgov/sips
+
+Created-by: SIP-000
+
+## Biographies
+
+Short descriptions of each member's background and experience.
+
+---
+
+**Name 1**: Details
+
+**Name 2**: Details
+
+**Name 3**: Details
+
+## About this CAB
+
+A description of the general considerations of the CAB, generally in one paragraph.
+
+## Considerations
+
+### In-scope
+
+The following items would be considered in-scope for this CAB:
+
+1. First item
+2. Second item
+3. Third item
+
+### Out-of-scope
+
+The following items would be considered out-of-scope for this CAB:
+
+1. First item
+2. Second item
+3. Third item
+
+### Questions for SIP Review
+
+1. Question/Prompt 1
+2. Question/Prompt 2
+3. Question/Prompt 3
+
+## Bylaws
+
+We choose to adopt the bylaws Steering Committee member @jcnelson set out in this doc: https://gist.github.com/jcnelson/3fcc635ede20ce98d1eae60941eb127a
+
+Starting form those bylaws, this CAB will continue to evaluate what works, what doesn't work, and use the feedback and lessons learned to improve the process and increase involvement along the way.
+
+---
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/diversity.md
+++ b/considerations/diversity.md
@@ -1,8 +1,11 @@
 # Consideration for Diversity SIPs
 
-Chairperson: Jude Nelson <jude@stacks.org>
+Chairperson: Jude Nelson
 
-Members: Jude Nelson <jude@stacks.org>, Hero Gamer <herogamerthesht572@gmail.com>
+Members:
+
+- Jude Nelson <jude@stacks.org>
+- Hero Gamer <herogamerthesht572@gmail.com>
 
 Discussions-to: https://github.com/stacksgov/sips
 
@@ -10,9 +13,8 @@ Created-by: SIP-000
 
 ## About
 
-This consideration advisory board is a place-holder for advancing SIPs from
-Recommended status.  Until there are at least three members of this board who
-are not on the steering committee, it shall be run by the steering committee.
+This consideration advisory board is a place-holder for advancing SIPs from Recommended status.
 
-Please reach out if you are interested in serving on this consideration advisory
-board!  We ask that you please read SIP-000 first if you choose to do so.
+Until there are at least three members of this board who are not on the steering committee, it shall be run by the steering committee.
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/economics.md
+++ b/considerations/economics.md
@@ -12,7 +12,7 @@ Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-### Biographies
+## Biographies
 
 **Dr. Chiente Hsu**: Dr. Chiente Hsu is CEO and co-founder of ALEX, the flagship DeFi on Bitcoin via Stacks. Dr. Hsu joins ALEX from Morgan Stanley and Credit Suisse, where she was a Managing Director and Global Head of Quant Research. She is also the author of ‘Rule Based Investing”, published by FT Press. Dr. Hsu spent her early career in academia. She was a tenure-track professor at the University of Vienna, Austria, and a visiting professor at Duke University, where she taught and conducted research in Financial Econometrics.
 

--- a/considerations/economics.md
+++ b/considerations/economics.md
@@ -22,7 +22,7 @@ Created-by: SIP-000
 
 ## About this CAB
 
-The SIP concerns the blockchain’s token economics. This not only includes the STX token, but also any on-chain tokens created within smart contracts. SIPs that are concerned with fundraising methods, grants, bounties, and so on also belong in this SIP track.
+The economics CAB reviews SIPs related to the blockchain's token economics. This not only includes the STX token, but also any on-chain tokens created within smart contracts. SIPs that are concerned with fundraising methods, grants, bounties, and so on also belong in this SIP track.
 
 ## Considerations
 

--- a/considerations/economics.md
+++ b/considerations/economics.md
@@ -1,18 +1,69 @@
 # Consideration for Economics SIPs
 
-Chairperson: Jude Nelson <jude@stacks.org>
+Chairperson: MattySTX
 
-Members: Jude Nelson <jude@stacks.org>, Juliet Oberding <juliet.oberding@gmail.com>, Xan Ditkoff <xan@daemontechnologies.co>
+Members:
+
+- Chiente Hsu <chiente@alexgo.io>
+- MattySTX <mattystx@gmail.com>
+- Xan Ditkoff <xan@daemontechnologies.co>
 
 Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-## About
+### Biographies
 
-This consideration advisory board is a place-holder for advancing SIPs from
-Recommended status.  Until there are at least three members of this board who
-are not on the steering committee, it shall be run by the steering committee.
+**Dr. Chiente Hsu**: Dr. Chiente Hsu is CEO and co-founder of ALEX, the flagship DeFi on Bitcoin via Stacks. Dr. Hsu joins ALEX from Morgan Stanley and Credit Suisse, where she was a Managing Director and Global Head of Quant Research. She is also the author of ‘Rule Based Investing”, published by FT Press. Dr. Hsu spent her early career in academia. She was a tenure-track professor at the University of Vienna, Austria, and a visiting professor at Duke University, where she taught and conducted research in Financial Econometrics.
 
-Please reach out if you are interested in serving on this consideration advisory
-board!  We ask that you please read SIP-000 first if you choose to do so.
+**MattySTX (Chairperson)**: Matty has more than a decade of experience designing, simulating, and optimizing economic models for hedge funds and VC funded machine learning startups. He has been in crypto since 2015, and Stacks since 2017. In the Stacks ecosystem, his simulation analysis of Stacks’ economic model has helped evaluate PoX consensus mechanism improvements, he authored the first ever community contributed governance proposal for Arkadiko’s tokenomics, he publishes the quarterly ‘STX Mining Report’, and he mentors teams at the Stacks incubator.
+
+**Xan Ditkoff**: Xan became part of the Stack’s ecosystem in 2017 as an early core team member focused on growing the developer ecosystem. He now runs Daemon Technologies, a Hong Kong based company focused on community growth, project funding, and partnerships for Stack’s technology primarily in Asia.
+
+## About this CAB
+
+The SIP concerns the blockchain’s token economics. This not only includes the STX token, but also any on-chain tokens created within smart contracts. SIPs that are concerned with fundraising methods, grants, bounties, and so on also belong in this SIP track.
+
+## Considerations
+
+### In-scope
+
+The following items would be considered in-scope for this CAB:
+
+1. Changes to the tokenomics of Stacks or the STX token itself
+2. Changes to Stacks’ consensus mechanism - particularly with regard to the impact on miners and stackers
+3. The economic impacts, and risks of economic impacts, that changes to the Stacks protocol would have on any and all parties in the Stacks ecosystem
+4. The economic soundness and viability of proposed standards for fungible or non-fungible tokens issued on STX
+5. Changes that put the existing economy on the Stacks chain at risk, or which may grow/shrink Stacks’ overall economic utility and activity
+6. Any economic impact or risk to native Bitcoin due to Stacks’ activity
+
+### Out-of-scope
+
+The following items would be considered out-of-scope for this CAB:
+
+1. The security of the Stacks network itself, beyond the economic risks and impacts of its ongoing security
+2. The particular tokenomics of any given project launching on Stacks
+3. The technical or implementation-level aspects of changes to the tokenomics of Stacks, the STX token itself, or Stack’s consensus mechanism (though any relative economic differences in technical approaches would be in-scope for this CAB)
+4. Improvements to the speed, performance, up-time, or other functioning of the Stacks network itself, other than any economic impacts or risks created by these changes
+
+### Questions for SIP Review
+
+Questions to facilitate SIP review:
+
+1. Which stakeholders are expected to be economically impacted, or at-risk of being economically impacted, by this SIP (ex. miners, stackers, STX holders, STX users, founders/builders, etc)?
+2. What are the expected economic impacts to each of these stakeholders?
+3. What are the economic and non-economic risks to each of these stakeholders?
+4. Do the expected economic benefits outweigh the economic and non-economic risks for each of these stakeholders?
+5. If one stakeholder would economically benefit at the expense of another stakeholder (for example increase profit to miners at cost of reducing yield to stackers), what is the expected overall economic net impact to Stacks and the Stacks ecosystem?
+
+_Note: above considerations subject to changes and iterations from ongoing lessons learned_
+
+## Bylaws
+
+We choose to adopt the bylaws Steering Committee member @jcnelson set out in this doc: https://gist.github.com/jcnelson/3fcc635ede20ce98d1eae60941eb127a
+
+Starting form those bylaws, this CAB will continue to evaluate what works, what doesn't work, and use the feedback and lessons learned to improve the process and increase involvement along the way.
+
+---
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/ethics.md
+++ b/considerations/ethics.md
@@ -1,8 +1,11 @@
 # Consideration for Ethics SIPs
 
-Chairperson: Jude Nelson <jude@stacks.org>
+Chairperson: Jude Nelson
 
-Members: Jude Nelson <jude@stacks.org>, Juliet Oberding <juliet.oberding@gmail.com> 
+Members:
+
+- Jude Nelson <jude@stacks.org>
+- Juliet Oberding <juliet.oberding@gmail.com>
 
 Discussions-to: https://github.com/stacksgov/sips
 
@@ -10,9 +13,8 @@ Created-by: SIP-000
 
 ## About
 
-This consideration advisory board is a place-holder for advancing SIPs from
-Recommended status.  Until there are at least three members of this board who
-are not on the steering committee, it shall be run by the steering committee.
+This consideration advisory board is a place-holder for advancing SIPs from Recommended status.
 
-Please reach out if you are interested in serving on this consideration advisory
-board!  We ask that you please read SIP-000 first if you choose to do so.
+Until there are at least three members of this board who are not on the steering committee, it shall be run by the steering committee.
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/governance.md
+++ b/considerations/governance.md
@@ -14,7 +14,7 @@ Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-### Biographies
+## Biographies
 
 **Harold Davis**: Started in the Blockstack ecosystem back in 2016. Became very involved with governance in 2020 with the governance working group. Established a governance residency focused on R+D of gov tooling for the Stacks Advocates & ecosystem. Specifically focused on distributed power for long term sustainability.
 

--- a/considerations/governance.md
+++ b/considerations/governance.md
@@ -57,7 +57,7 @@ The following items would be considered out-of-scope for this CAB:
 
 Questions to facilitate SIP review:
 
-1. Which stakeholders' governance processes are expected to be impacted, or at-risk of being impacted, by this SIP (ex. miners, stakers, STX holders, STX users, STX builders, etc)?
+1. Which stakeholders' governance processes are expected to be impacted, or at-risk of being impacted, by this SIP (ex. miners, stackers, STX holders, STX users, STX builders, etc)?
 2. What are the expected governance impacts to each of these parties?
 3. What are the governance and non-governance risks to each of these parties?
 4. Do the expected governance benefits outweigh the governance and non-governance risks for each of these parties?

--- a/considerations/governance.md
+++ b/considerations/governance.md
@@ -1,7 +1,5 @@
 # Consideration for Governance SIPs
 
-## Member Information
-
 Chairperson: Jason Schrader
 
 Members:

--- a/considerations/governance.md
+++ b/considerations/governance.md
@@ -1,27 +1,78 @@
 # Consideration for Governance SIPs
 
-Chairperson: Jason Schrader <jason@joinfreehold.com>
+## Member Information
 
-Members: Harold Davis <recursive3@gmail.com>, Juliet Oberding
-<juliet.oberding@gmail.com>, Jason Schrader <jason@joinfreehold.com>, Orlando Cosme <orlando@stackerdaos.com>,
+Chairperson: Jason Schrader
+
+Members:
+
+- Harold Davis <recursive3@gmail.com>
+- Juliet Oberding <juliet.oberding@gmail.com>
+- Orlando Cosme <orlando@stackerdaos.com>
+- Zero.btc <zero@zeroauthority.xyz>
+- Jason Schrader <jason@joinfreehold.com>
 
 Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-## About
+### Biographies
+
+**Harold Davis**: Started in the Blockstack ecosystem back in 2016. Became very involved with governance in 2020 with the governance working group. Established a governance residency focused on R+D of gov tooling for the Stacks Advocates & ecosystem. Specifically focused on distributed power for long term sustainability.
+
+**Juliet Oberding**: Juliet is a long time member of the Stacks community. She participated in App Mining, was an original member of the Governance working group, developed the Stacks Code of Conduct and was a resident with the Stacks Gov Lab. Her background is as a lawyer, law professor and founder of a digital health startup. Juliet is currently the founder of Lexy Lab, a startup focused on governance research.
+
+**Orlando Cosme**: Orlando first got involved in Stacks when mainnet launched. He is the co-founder & CEO of StackerDAO Labs, a startup that develops infrastructure and tools to create and manage DAOs on Stacks. He is also a lawyer and had stints as a startup/VC corporate lawyer and a securities and government enforcement litigator. Through StackerDAOs and as an attorney, he has developed both on-chain, decentralized governance structures, as well as traditional corporate governance structures. He has also worked on corporate governance disputes.
+
+**Zero.btc**: Zero has been involved with the Stacks community since the BlockStack days and he learned about Stacks during the regulated ICO. He is the co-founder of Zero Authority DAO, and he and his co-founder Hodlstx created the Cerulean Marketplace for creators and builders to offer a service and for people to pay for Web3 gigs in a trustless and permissionless way. Being a part of the governance CAB is an honor and he has spent lots of time working on governance for the DAO they have built.
+
+**Jason Schrader (Chairperson)**: Stacks community member since 2019, engineer at Freehold and a core developer of the CityCoins protocol. Participated in the formation of the Stacks Governance Working Group and helps with research, tooling, and project management. An open source advocate and teacher at heart - we're all learning together!
+
+## About this CAB
 
 The governance CAB concerns the governance of the Stacks blockchain, including the SIP process. This includes amendments to the SIP Ratification Process, as well as structural considerations such as the creation (or removal) of various committees, editorial bodies, and formally recognized special interest groups. In addition, governance SIPs may propose changes to the way by which committee members are selected.
 
 ## Considerations
 
+### In-scope
+
 The following items would be considered in-scope for this CAB:
 
-- changes to the SIP process
-- changes to the way we represent blockchain stakeholders
-- changes to the code of conduct
-- changes to the way we organize Stacks chapters
-- changes to voting/decision making processes
-- changes to community representative to board
-- changes that impact community members
-- changes that impact all STX holders/investors
+1. changes to the SIP process
+2. changes to the way we represent blockchain stakeholders
+3. changes to the code of conduct
+4. changes to the way we organize Stacks chapters
+5. changes to voting/decision making processes
+6. changes to community representative to board
+7. changes that impact community members
+8. changes that impact all STX holders/investors
+
+### Out-of-scope
+
+The following items would be considered out-of-scope for this CAB:
+
+1. The security of the Stacks network itself, beyond the governance risks and impacts of its ongoing security.
+2. The particular governance of any given project launching on Stacks
+3. Improvements to the speed, performance, up-time, or other functioning of the Stacks network itself, other than any governance impacts or risks created by these changes
+
+### Questions for SIP Review
+
+Questions to facilitate SIP review:
+
+1. Which stakeholders' governance processes are expected to be impacted, or at-risk of being impacted, by this SIP (ex. miners, stakers, STX holders, STX users, STX builders, etc)?
+2. What are the expected governance impacts to each of these parties?
+3. What are the governance and non-governance risks to each of these parties?
+4. Do the expected governance benefits outweigh the governance and non-governance risks for each of these parties?
+5. If one party would benefit in decision making power at the expense of another party (for example increase decision making power to miners at cost of less decision making to stackers), what is the likely overall, net decision making power impact to Stacks and the Stacks ecosystem?
+
+_Note: above considerations subject to changes and iterations from ongoing lessons learned_
+
+## Bylaws
+
+We choose to adopt the bylaws Steering Committee member @jcnelson set out in this doc: https://gist.github.com/jcnelson/3fcc635ede20ce98d1eae60941eb127a
+
+Starting form those bylaws, this CAB will continue to evaluate what works, what doesn't work, and use the feedback and lessons learned to improve the process and increase involvement along the way.
+
+---
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/technical.md
+++ b/considerations/technical.md
@@ -41,7 +41,7 @@ Working in The Clarity Innovation Lab - a research and development centre focuse
 
 ## About this CAB
 
-The SIP is technical in nature, and must be vetted by users with the relevant technical expertise.
+The technical CAB reviews SIPs related to technical implementations to the blockchain, including consensus-breaking changes. SIPs tahat are technical in nature and must be vetted by users with the relevant technical expertise belong in this SIP track.
 
 ## Considerations
 

--- a/considerations/technical.md
+++ b/considerations/technical.md
@@ -1,18 +1,81 @@
 # Consideration for Technical SIPs
 
-Chairperson: Jude Nelson <jude@stacks.org>
+Chairperson: Brice Dobry
 
-Members: Jude Nelson <jude@stacks.org>, Aaron Blankstein <aaron@hiro.so>, Brice Dobry <brice@hiro.so>, Thomas Osmonson (aulneau) <thomas@fungible.systems>
+Members:
+
+- Aaron Blankstein <aaron@hiro.so>
+- Brice Dobry <brice@hiro.so>
+- Dan Trevino <dantrevino@gmail.com>
+- Daniel Fritsche <daniel@byzantion.xyz>
+- Jamil Dhanani <jamil@gamma.io>
+- Jesse Wiley <jesse@stacks.org>
+- Mike Cohen <mike@claritylab.dev>
+- Terje Norderhaug <terje@in-progress.com>>
+- Thomas Osmonson a.k.a aulneau <thomas@fungible.systems>
 
 Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-## About
+### Biographies
 
-This consideration advisory board is a place-holder for advancing SIPs from
-Recommended status.  Until there are at least three members of this board who
-are not on the steering committee, it shall be run by the steering committee.
+**Aaron Blankstein**: Aaron is a staff engineer at Hiro, contributing to the Stacks blockchain, Clarity, and Hiro’s subnets implementation. He has been working on the Stacks blockchain for 5+ years, working on Proof-of-Transfer consensus, Clarity, and other projects.
 
-Please reach out if you are interested in serving on this consideration advisory
-board!  We ask that you please read SIP-000 first if you choose to do so.
+**Brice Dobry (Chairperson)**: Brice is a senior engineer at Hiro, working on Clarinet and other developer tools, and contributing to the Stacks blockchain. Coming from a background in compilers, programming languages, and analysis tools, he is passionate about helping developers build productively, efficiently and safely.
+
+**Dan Trevino**: Dan is the founder of Boom Cypto and an advocate for open standards. Dan has contributed to the Stacks community as an advocate, developer, speaker, and mentor since 2016.
+
+**Daniel Fritsche**: Daniel is the co-founder of Byzantion, a cross-chain infrastructure and trading platform creating seamless cross-chain experiences for developers and users. Prior to Byzantion, he was the Vice President of Data Strategy at Stephens Inc.
+
+**Jamil Dhanani**: Jamil is the Founder and CEO of Gamma.io, the leading marketplace and creator platform for NFTs on Bitcoin, built on Stacks. Prior to founding Gamma, he worked as a Machine Learning Engineer and Researcher at Apple, and studied Computer Science at Stanford and the University of Toronto.
+
+**Jesse Wiley**: Jesse Wiley is a seasoned DevOps expert - he makes sure all systems are running smoothly and the right security considerations have been made.
+
+**Mike Cohen**: Advocate of Bitcoin, Stacks, Lightning Blockchain web3 technologies and the User Owned Internet.
+Working in The Clarity Innovation Lab - a research and development centre focused on the Clarity Smart Contract programming language - pushing the boundaries of decentralised apps on Bitcoin.
+
+**Terje Norderhaug**: Independent software developer. Clarity developer.
+
+**Thomas Osmonson a.k.a aulneau**: Thomas is co-founder and CEO of Fungible Systems, a web3 and crypto focused product studio. Fungible Systems works extensively in the Stacks ecosystem building public goods, open source tooling, and helping projects such as Gamma, Zest, Trust Machines, and others. Previously, Thomas was part of the early core team that helped build the Stacks network.
+
+## About this CAB
+
+The SIP is technical in nature, and must be vetted by users with the relevant technical expertise.
+
+## Considerations
+
+### In-scope
+
+The following items would be considered in-scope for this CAB:
+
+1. Changes to Clarity syntax and semantics
+2. Changes to Clarity functions or keywords
+3. Changes to the Stacks blockchain’s consensus mechanisms
+4. Changes to the Stacks blockchain’s wire formats
+5. Changes to the networking protocols in the Stacks blockchain
+6. Proposed standards for Clarity contracts
+
+### Out-of-scope
+
+The following items would be considered out-of-scope for this CAB:
+
+1. Changes to the consensus protocol that are strictly limited to financial or economic considerations
+
+### Questions for SIP Review
+
+1. Are there any consensus consequences for the proposal? If so, what are they?
+2. What components of the network are impacted?
+3. What are the activation requirements? Can non-technical users participate in activation?
+
+_Note: above considerations subject to changes and iterations from ongoing lessons learned_
+
+## Bylaws
+
+We choose to adopt the bylaws Steering Committee member @jcnelson set out in this doc: https://gist.github.com/jcnelson/3fcc635ede20ce98d1eae60941eb127a
+
+Starting form those bylaws, this CAB will continue to evaluate what works, what doesn't work, and use the feedback and lessons learned to improve the process and increase involvement along the way.
+
+---
+
+_If this CAB interests you and you wish to join the effort, please reach out to @jennymith and @Hero-Gamer or Steering Committee members @jcnelson and @GinaAbrams_

--- a/considerations/technical.md
+++ b/considerations/technical.md
@@ -18,7 +18,7 @@ Discussions-to: https://github.com/stacksgov/sips
 
 Created-by: SIP-000
 
-### Biographies
+## Biographies
 
 **Aaron Blankstein**: Aaron is a staff engineer at Hiro, contributing to the Stacks blockchain, Clarity, and Hiro’s subnets implementation. He has been working on the Stacks blockchain for 5+ years, working on Proof-of-Transfer consensus, Clarity, and other projects.
 
@@ -41,7 +41,7 @@ Working in The Clarity Innovation Lab - a research and development centre focuse
 
 ## About this CAB
 
-The technical CAB reviews SIPs related to technical implementations to the blockchain, including consensus-breaking changes. SIPs tahat are technical in nature and must be vetted by users with the relevant technical expertise belong in this SIP track.
+The technical CAB reviews SIPs related to technical implementations to the blockchain, including consensus-breaking changes. SIPs that are technical in nature and must be vetted by users with the relevant technical expertise belong in this SIP track.
 
 ## Considerations
 


### PR DESCRIPTION
This PR takes the excellent work done by @Hero-Gamer and codifies it into the original SIPs repository regarding CABs, members, and related information.

Linked forum posts for reference:
- [Activation of **Governance Consideration Advisory Board (CAB)**](https://forum.stacks.org/t/activation-of-governance-consideration-advisory-board-cab/13763/2)
- [Activation of **Economics Consideration Advisory Board (CAB)**](https://forum.stacks.org/t/activation-of-economics-consideration-advisory-board-cab/13762/2)
- [Activation of **Technical Consideration Advisory Board (CAB)**](https://forum.stacks.org/t/activation-of-technical-consideration-advisory-board-cab/13761/2)

This PR also supersedes #87 and adds the same info but in the new format - so once merged that one can be closed as well.