### PR TITLE
SIP-020 bitwise operators to Clarity 2

### DIFF
--- a/sips/sip-020/sip-020-bitwise-ops.md
+++ b/sips/sip-020/sip-020-bitwise-ops.md
@@ -11,7 +11,7 @@ Consideration: Technical, Governance
 
 Type: Consensus
 
-Status: Recommended
+Status: Activation-in-Progress
 
 Created: 12 November 2022
 

--- a/sips/sip-020/sip-020-bitwise-ops.md
+++ b/sips/sip-020/sip-020-bitwise-ops.md
@@ -11,13 +11,13 @@ Consideration: Technical, Governance
 
 Type: Consensus
 
-Status: Draft
+Status: Recommended
 
 Created: 12 November 2022
 
 License: CC0-1.0
 
-Sign-off:
+Sign-off: Jason Schrader <jason@joinfreehold.com>, Jesse Wiley <jesse@stacks.org>
 
 Layer: Consensus (hard fork)
 

--- a/sips/sip-020/sip-020-bitwise-ops.md
+++ b/sips/sip-020/sip-020-bitwise-ops.md
@@ -1,6 +1,6 @@
 # Preamble
 
-SIP Number: XYZ
+SIP Number: 020
 
 Title: Bitwise Operations in Clarity
 

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -119,8 +119,11 @@ inputs.
 - **Inputs:** int | uint
 - **Output:** int | uint
 
-Returns the result of bitwise not, effectively reversing the bits of `i1` (1's
-complement).
+Returns the one's compliment (sometimes also called the bitwise compliment or
+not operator) of `i1`, effectively reversing the bits in `i1`.
+
+In other words, every bit that is `1` in `ì1` will be `0` in the result.
+Conversely, every bit that is `0` in `i1` will be `1` in the result.
 
 ### Examples
 
@@ -195,3 +198,5 @@ This SIP will be a rider on SIP-015. It will be considered activated if SIP-015
 # Reference Implementations
 
 - https://github.com/stacks-network/stacks-blockchain/pull/3389
+- See also discussions in
+  https://github.com/stacks-network/stacks-blockchain/pull/3382

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -51,7 +51,8 @@ bit field for example, would be much more difficult to implement without the use
 of these operations. When executing a contract using these operations, the
 common hardware on which miners and nodes are likely to be running can all
 perform these operations very efficiently -- these are typically single cycle
-operations.
+operations. Note that the addition of these bitwise operations commits the
+Clarity VM to using 2's complement to represent integers.
 
 # Specification
 
@@ -144,6 +145,8 @@ Conversely, every bit that is `0` in `i1` will be `1` in the result.
 
 Shifts all bits in `i1` to the left by the number of places specified in `shamt`
 modulo 128 (the bit width of Clarity integers). New bits are filled with zeros.
+When `i1` is a `uint` (unsigned), this is a logical shift. When `i1` is an `int`
+(signed), this is an arithmetic shift, preserving the sign.
 
 ### Examples
 
@@ -193,8 +196,8 @@ this SIP is activated, and valid after it is activated.
 
 # Activation
 
-This SIP will be a rider on SIP-015. It will be considered activated if SIP-015
-(and Stacks 2.1) is activated.
+This SIP will be a rider on SIP-015. It will be considered activated if and only
+if SIP-015 (and Stacks 2.1) is activated.
 
 # Reference Implementations
 

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -46,11 +46,12 @@ by the Stacks Open Internet Foundation.
 # Introduction
 
 Bitwise operations are common in other programming languages. Common algorithms,
-including many used in encryption for example, would be much more difficult to
-implement without the use of these operations. When executing a contract using
-these operations, the common hardware on which miners and nodes are likely to be
-running can all perform these operations very efficiently -- these are typically
-single cycle operations.
+including many used in encryption, or the ability to set and check flags in a
+bit field for example, would be much more difficult to implement without the use
+of these operations. When executing a contract using these operations, the
+common hardware on which miners and nodes are likely to be running can all
+perform these operations very efficiently -- these are typically single cycle
+operations.
 
 # Specification
 

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -145,18 +145,21 @@ Conversely, every bit that is `0` in `i1` will be `1` in the result.
 
 Shifts all bits in `i1` to the left by the number of places specified in `shamt`
 modulo 128 (the bit width of Clarity integers). New bits are filled with zeros.
-When `i1` is a `uint` (unsigned), this is a logical shift. When `i1` is an `int`
-(signed), this is an arithmetic shift, preserving the sign.
+
+Note that there is a deliberate choice made to ignore arithmetic overflow for
+this operation. In use cases where overflow should be detected, developers
+should use `*`, `/`, and `pow` instead of the shift operators.
 
 ### Examples
 
 ```
-(<< 2 u1) ;; Returns 4
 (<< 16 u2) ;; Returns 64
 (<< -64 u1) ;; Returns -128
 (<< u4 u2) ;; Returns u16
-(<< u240282366920938463463374607431768211327 u3) ;; Returns 30756142965880123323311949751266331049856
-(<< u123 u24028236699) ;; Returns 16508780544 (123 << 27)
+(<< 123 u9999999999) ;; Returns -170141183460469231731687303715884105728 (== 123 << 127)
+(<< u123 u9999999999) ;; Returns u170141183460469231731687303715884105728 (== u123 << 127)
+(<< -1 u7) ;; Returns -128
+(<< -1 u128) ;; Returns -1
 ```
 
 ## Bitwise Right Shift (`>>`)
@@ -172,6 +175,10 @@ Shifts all the bits in `i1` to the right by the number of places specified in
 sign is preserved, meaning that new bits are filled with the value of the
 previous sign-bit.
 
+Note that there is a deliberate choice made to ignore arithmetic overflow for
+this operation. In use cases where overflow should be detected, developers
+should use `*`, `/`, and `pow` instead of the shift operators.
+
 ### Examples
 
 ```
@@ -179,9 +186,12 @@ previous sign-bit.
 (>> 128 u2) ;; Returns 32
 (>> -64 u1) ;; Returns -32
 (>> u128 u2) ;; Returns u32
-(>> u240282366920938463463374607431768211327 u127) ;; Returns 0
-(>> u123 u2402820) ;; Returns 7 (u123 >> 4)
-(>> -3 u12) ;; Returns -1
+(>> 123 u9999999999) ;; Returns 0
+(>> u123 u9999999999) ;; Returns u0
+(>> -128 u7) ;; Returns -1
+(>> -256 u1) ;; Returns -128
+(>> 5 u2) ;; Returns 1
+(>> -5 u2) ;; Returns -2
 ```
 
 # Related work

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -29,12 +29,12 @@ This SIP adds bitwise operations to the Clarity language which could simplify
 the implementation of smart contracts that require manipulation of bits. The
 changes include the addition of the following operations:
 
-- Bitwise Xor (`^`)
-- Bitwise And (`&`)
-- Bitwise Or (`|`)
-- Bitwise Not (`~`)
-- Binary Left Shift (`<<`)
-- Binary Right Shift (`>>`)
+- Bitwise Xor (`bit-xor`)
+- Bitwise And (`bit-and`)
+- Bitwise Or (`bit-or`)
+- Bitwise Not (`bit-not`)
+- Binary Left Shift (`bit-shift-left`)
+- Binary Right Shift (`bit-shift-right`)
 
 # License and Copyright
 
@@ -56,9 +56,9 @@ Clarity VM to using 2's complement to represent integers.
 
 # Specification
 
-## Bitwise Xor (`^`)
+## Bitwise Xor (`bit-xor`)
 
-`(^ i1 i2...)`
+`(bit-xor i1 i2...)`
 
 - **Inputs:** int, ... | uint, ...
 - **Output:** int | uint
@@ -69,16 +69,16 @@ inputs.
 ### Examples
 
 ```
-(^ 1 2) ;; Returns 3
-(^ 120 280) ;; Returns 352
-(^ -128 64) ;; Returns -64
-(^ u24 u4) ;; Returns u28
-(^ 1 2 4 -1) ;; Returns -8
+(bit-xor 1 2) ;; Returns 3
+(bit-xor 120 280) ;; Returns 352
+(bit-xor -128 64) ;; Returns -64
+(bit-xor u24 u4) ;; Returns u28
+(bit-xor 1 2 4 -1) ;; Returns -8
 ```
 
-## Bitwise And (`&`)
+## Bitwise And (`bit-and`)
 
-`(& i1 i2...)`
+`(bit-and i1 i2...)`
 
 - **Inputs:** int, ... | uint, ...
 - **Output:** int | uint
@@ -88,16 +88,16 @@ Returns the result of bitwise and'ing a variable number of integer inputs.
 ### Examples
 
 ```
-(& 24 16) ;; Returns 16
-(& 28 24 -1) ;; Returns 24
-(& u24 u16) ;; Returns u16
-(& -128 -64) ;; Returns -128
-(& 28 24 -1) ;; Returns 24
+(bit-and 24 16) ;; Returns 16
+(bit-and 28 24 -1) ;; Returns 24
+(bit-and u24 u16) ;; Returns u16
+(bit-and -128 -64) ;; Returns -128
+(bit-and 28 24 -1) ;; Returns 24
 ```
 
-## Bitwise Or (`|`)
+## Bitwise Or (`bit-or`)
 
-`(& i1 i2...)`
+`(bit-or i1 i2...)`
 
 - **Inputs:** int, ... | uint, ...
 - **Outputs:** int | uint
@@ -108,15 +108,15 @@ inputs.
 ### Examples
 
 ```
-(| 4 8) ;; Returns 12
-(| 1 2 4) ;; Returns 7
-(| 64 -32 -16) ;; Returns -16
-(| u2 u4 u32) ;; Returns u38
+(bit-or 4 8) ;; Returns 12
+(bit-or 1 2 4) ;; Returns 7
+(bit-or 64 -32 -16) ;; Returns -16
+(bit-or u2 u4 u32) ;; Returns u38
 ```
 
-## Bitwise Not (`~`)
+## Bitwise Not (`bit-not`)
 
-`(~ i1)`
+`(bit-not i1)`
 
 - **Inputs:** int | uint
 - **Output:** int | uint
@@ -130,15 +130,15 @@ Conversely, every bit that is `0` in `i1` will be `1` in the result.
 ### Examples
 
 ```
-(~ 3) ;; Returns -4
-(~ u128) ;; Returns u340282366920938463463374607431768211327
-(~ 128) ;; Returns -129
-(~ -128) ;; Returns 127
+(bit-not 3) ;; Returns -4
+(bit-not u128) ;; Returns u340282366920938463463374607431768211327
+(bit-not 128) ;; Returns -129
+(bit-not -128) ;; Returns 127
 ```
 
-## Bitwise Left Shift (`<<`)
+## Bitwise Left Shift (`bit-shift-left`)
 
-`(<< i1 shamt)`
+`(bit-shift-left i1 shamt)`
 
 - **Inputs:** int, uint | uint, uint
 - **Outputs:** int | uint
@@ -153,18 +153,18 @@ should use `*`, `/`, and `pow` instead of the shift operators.
 ### Examples
 
 ```
-(<< 16 u2) ;; Returns 64
-(<< -64 u1) ;; Returns -128
-(<< u4 u2) ;; Returns u16
-(<< 123 u9999999999) ;; Returns -170141183460469231731687303715884105728 (== 123 << 127)
-(<< u123 u9999999999) ;; Returns u170141183460469231731687303715884105728 (== u123 << 127)
-(<< -1 u7) ;; Returns -128
-(<< -1 u128) ;; Returns -1
+(bit-shift-left 16 u2) ;; Returns 64
+(bit-shift-left -64 u1) ;; Returns -128
+(bit-shift-left u4 u2) ;; Returns u16
+(bit-shift-left 123 u9999999999) ;; Returns -170141183460469231731687303715884105728 (== 123 bit-shift-left 127)
+(bit-shift-left u123 u9999999999) ;; Returns u170141183460469231731687303715884105728 (== u123 bit-shift-left 127)
+(bit-shift-left -1 u7) ;; Returns -128
+(bit-shift-left -1 u128) ;; Returns -1
 ```
 
-## Bitwise Right Shift (`>>`)
+## Bitwise Right Shift (`bit-shift-right`)
 
-`(>> i1 shamt)`
+`(bit-shift-right i1 shamt)`
 
 - **Inputs:** int, uint | uint, uint
 - **Output:** int | uint
@@ -182,16 +182,16 @@ should use `*`, `/`, and `pow` instead of the shift operators.
 ### Examples
 
 ```
-(>> 2 u1) ;; Returns 1
-(>> 128 u2) ;; Returns 32
-(>> -64 u1) ;; Returns -32
-(>> u128 u2) ;; Returns u32
-(>> 123 u9999999999) ;; Returns 0
-(>> u123 u9999999999) ;; Returns u0
-(>> -128 u7) ;; Returns -1
-(>> -256 u1) ;; Returns -128
-(>> 5 u2) ;; Returns 1
-(>> -5 u2) ;; Returns -2
+(bit-shift-right 2 u1) ;; Returns 1
+(bit-shift-right 128 u2) ;; Returns 32
+(bit-shift-right -64 u1) ;; Returns -32
+(bit-shift-right u128 u2) ;; Returns u32
+(bit-shift-right 123 u9999999999) ;; Returns 0
+(bit-shift-right u123 u9999999999) ;; Returns u0
+(bit-shift-right -128 u7) ;; Returns -1
+(bit-shift-right -256 u1) ;; Returns -128
+(bit-shift-right 5 u2) ;; Returns 1
+(bit-shift-right -5 u2) ;; Returns -2
 ```
 
 # Related work

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -66,6 +66,24 @@ Clarity VM to using 2's complement to represent integers.
 Returns the result of bitwise exclusive or'ing a variable number of integer
 inputs.
 
+| Bit in i1 | Bit in i2 | Bit in Output |
+| --------- | --------- | ------------- |
+| 0         | 0         | 0             |
+| 0         | 1         | 1             |
+| 1         | 0         | 1             |
+| 1         | 1         | 0             |
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-xor 17 30) ;; Return 15
+;; Binary representation:
+;; i1 (17):     00010001
+;; i2 (30):     00011110
+;; Output (15): 00001111
+```
+
 ### Examples
 
 ```
@@ -84,6 +102,24 @@ inputs.
 - **Output:** int | uint
 
 Returns the result of bitwise and'ing a variable number of integer inputs.
+
+| Bit in i1 | Bit in i2 | Bit in Output |
+| --------- | --------- | ------------- |
+| 0         | 0         | 0             |
+| 0         | 1         | 0             |
+| 1         | 0         | 0             |
+| 1         | 1         | 1             |
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-and 17 30) ;; Return 16
+;; Binary representation:
+;; i1 (17):     00010001
+;; i2 (30):     00011110
+;; Output (16): 00010000
+```
 
 ### Examples
 
@@ -104,6 +140,24 @@ Returns the result of bitwise and'ing a variable number of integer inputs.
 
 Returns the result of bitwise inclusive or'ing a variable number of integer
 inputs.
+
+| Bit in i1 | Bit in i2 | Bit in Output |
+| --------- | --------- | ------------- |
+| 0         | 0         | 0             |
+| 0         | 1         | 1             |
+| 1         | 0         | 1             |
+| 1         | 1         | 1             |
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-or 17 30) ;; Return 31
+;; Binary representation:
+;; i1 (17):     00010001
+;; i2 (30):     00011110
+;; Output (31): 00011111
+```
 
 ### Examples
 
@@ -127,6 +181,21 @@ not operator) of `i1`, effectively reversing the bits in `i1`.
 In other words, every bit that is `1` in `ì1` will be `0` in the result.
 Conversely, every bit that is `0` in `i1` will be `1` in the result.
 
+| Bit in i1 | Bit in Output |
+| --------- | ------------- |
+| 0         | 1             |
+| 1         | 0             |
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-not u41) ;; Return u214
+;; Binary representation:
+;; i1 (41):      00101001
+;; Output (214): 11010110
+```
+
 ### Examples
 
 ```
@@ -149,6 +218,16 @@ modulo 128 (the bit width of Clarity integers). New bits are filled with zeros.
 Note that there is a deliberate choice made to ignore arithmetic overflow for
 this operation. In use cases where overflow should be detected, developers
 should use `*`, `/`, and `pow` instead of the shift operators.
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-shift-left 6 u3) ;; Return 48
+;; Binary representation:
+;; Input  (6):  00000110
+;; Output (48): 00110000
+```
 
 ### Examples
 
@@ -178,6 +257,16 @@ previous sign-bit.
 Note that there is a deliberate choice made to ignore arithmetic overflow for
 this operation. In use cases where overflow should be detected, developers
 should use `*`, `/`, and `pow` instead of the shift operators.
+
+The following example uses only 8 bits to make it easier to follow. Actual
+Clarity values are 128 bits.
+
+```
+(bit-shift-right u170 u1) ;; Return u85
+;; Binary representation:
+;; Input  (u170): 10101010
+;; Output (u85):  01010101
+```
 
 ### Examples
 

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -1,0 +1,195 @@
+# Preamble
+
+SIP Number: XYZ
+
+Title: Bitwise Operations in Clarity
+
+Authors: Cyle Witruk <https://github.com/cylewitruk>, Brice Dobry
+<https://github.com/obycode>
+
+Consideration: Technical, Governance
+
+Type: Consensus
+
+Status: Draft
+
+Created: 12 November 2022
+
+License: CC0-1.0
+
+Sign-off:
+
+Layer: Consensus (hard fork)
+
+Discussions-To: https://github.com/stacksgov/sips
+
+# Abstract
+
+This SIP adds bitwise operations to the Clarity language which could simplify
+the implementation of smart contracts that require manipulation of bits. The
+changes include the addition of the following operations:
+
+- Bitwise Xor (`^`)
+- Bitwise And (`&`)
+- Bitwise Or (`|`)
+- Bitwise Not (`~`)
+- Binary Left Shift (`<<`)
+- Binary Right Shift (`>>`)
+
+# License and Copyright
+
+This SIP is made available under the terms of the Creative Commons CC0 1.0
+Universal license, available at
+https://creativecommons.org/publicdomain/zero/1.0/ This SIP's copyright is held
+by the Stacks Open Internet Foundation.
+
+# Introduction
+
+Bitwise operations are common in other programming languages. Common algorithms,
+including many used in encryption for example, would be much more difficult to
+implement without the use of these operations. When executing a contract using
+these operations, the common hardware on which miners and nodes are likely to be
+running can all perform these operations very efficiently -- these are typically
+single cycle operations.
+
+# Specification
+
+## Bitwise Xor (`^`)
+
+`(^ i1 i2...)`
+
+- **Inputs:** int, ... | uint, ...
+- **Output:** int | uint
+
+Returns the result of bitwise exclusive or'ing a variable number of integer
+inputs.
+
+### Examples
+
+```
+(^ 1 2) ;; Returns 3
+(^ 120 280) ;; Returns 352
+(^ -128 64) ;; Returns -64
+(^ u24 u4) ;; Returns u28
+(^ 1 2 4 -1) ;; Returns -8
+```
+
+## Bitwise And (`&`)
+
+`(& i1 i2...)`
+
+- **Inputs:** int, ... | uint, ...
+- **Output:** int | uint
+
+Returns the result of bitwise and'ing a variable number of integer inputs.
+
+### Examples
+
+```
+(& 24 16) ;; Returns 16
+(& 28 24 -1) ;; Returns 24
+(& u24 u16) ;; Returns u16
+(& -128 -64) ;; Returns -128
+(& 28 24 -1) ;; Returns 24
+```
+
+## Bitwise Or (`|`)
+
+`(& i1 i2...)`
+
+- **Inputs:** int, ... | uint, ...
+- **Outputs:** int | uint
+
+Returns the result of bitwise inclusive or'ing a variable number of integer
+inputs.
+
+### Examples
+
+```
+(| 4 8) ;; Returns 12
+(| 1 2 4) ;; Returns 7
+(| 64 -32 -16) ;; Returns -16
+(| u2 u4 u32) ;; Returns u38
+```
+
+## Bitwise Not (`~`)
+
+`(~ i1)`
+
+- **Inputs:** int | uint
+- **Output:** int | uint
+
+Returns the result of bitwise not, effectively reversing the bits of `i1` (1's
+complement).
+
+### Examples
+
+```
+(~ 3) ;; Returns -4
+(~ u128) ;; Returns u340282366920938463463374607431768211327
+(~ 128) ;; Returns -129
+(~ -128) ;; Returns 127
+```
+
+## Bitwise Left Shift (`<<`)
+
+`(<< i1 i2)`
+
+- **Inputs:** int, uint | uint, uint
+- **Outputs:** int | uint
+
+Shifts all the bits in `i1` to the left by the number of places specified in
+`i2`. New bits are filled with zeros.
+
+### Examples
+
+```
+(<< 2 u1) ;; Returns 4
+(<< 16 u2) ;; Returns 64
+(<< -64 u1) ;; Returns -128
+(<< u4 u2) ;; Returns u16
+(<< u240282366920938463463374607431768211327 u3) ;; Returns 30756142965880123323311949751266331049856
+(<< u123 u24028236699) ;; Returns 0
+```
+
+## Bitwise Right Shift (`>>`)
+
+`(>> i1 i2)`
+
+- **Inputs:** int, uint | uint, uint
+- **Output:** int | uint
+
+Shifts all the bits in `i1` to the right by the number of places specified in
+`i2`. When `i1` is a `uint` (unsigned), new bits are filled with zeros. When
+`i1` is an `int` (signed), the sign is preserved, meaning that new bits are
+filled with the value of the previous sign-bit.
+
+### Examples
+
+```
+(>> 2 u1) ;; Returns 1
+(>> 128 u2) ;; Returns 32
+(>> -64 u1) ;; Returns -32
+(>> u128 u2) ;; Returns u32
+(>> u240282366920938463463374607431768211327 u2402823) ;; Returns u0
+(>> -3 u300) ;; Returns -1
+```
+
+# Related work
+
+Not applicable
+
+# Backwards Compatibility
+
+Because this SIP introduces new Clarity operators, it is a consensus-breaking
+change. A contract that uses one of these new operators would be invalid before
+this SIP is activated, and valid after it is activated.
+
+# Activation
+
+This SIP will be a rider on SIP-015. It will be considered activated if SIP-015
+(and Stacks 2.1) is activated.
+
+# Reference Implementations
+
+- https://github.com/stacks-network/stacks-blockchain/pull/3389

--- a/sips/sip-xyz/sip-xyz-bitwise-ops.md
+++ b/sips/sip-xyz/sip-xyz-bitwise-ops.md
@@ -133,13 +133,13 @@ complement).
 
 ## Bitwise Left Shift (`<<`)
 
-`(<< i1 i2)`
+`(<< i1 shamt)`
 
 - **Inputs:** int, uint | uint, uint
 - **Outputs:** int | uint
 
-Shifts all the bits in `i1` to the left by the number of places specified in
-`i2`. New bits are filled with zeros.
+Shifts all bits in `i1` to the left by the number of places specified in `shamt`
+modulo 128 (the bit width of Clarity integers). New bits are filled with zeros.
 
 ### Examples
 
@@ -149,20 +149,21 @@ Shifts all the bits in `i1` to the left by the number of places specified in
 (<< -64 u1) ;; Returns -128
 (<< u4 u2) ;; Returns u16
 (<< u240282366920938463463374607431768211327 u3) ;; Returns 30756142965880123323311949751266331049856
-(<< u123 u24028236699) ;; Returns 0
+(<< u123 u24028236699) ;; Returns 16508780544 (123 << 27)
 ```
 
 ## Bitwise Right Shift (`>>`)
 
-`(>> i1 i2)`
+`(>> i1 shamt)`
 
 - **Inputs:** int, uint | uint, uint
 - **Output:** int | uint
 
 Shifts all the bits in `i1` to the right by the number of places specified in
-`i2`. When `i1` is a `uint` (unsigned), new bits are filled with zeros. When
-`i1` is an `int` (signed), the sign is preserved, meaning that new bits are
-filled with the value of the previous sign-bit.
+`shamt` modulo 128 (the bit width of Clarity integers). When `i1` is a `uint`
+(unsigned), new bits are filled with zeros. When `i1` is an `int` (signed), the
+sign is preserved, meaning that new bits are filled with the value of the
+previous sign-bit.
 
 ### Examples
 
@@ -171,8 +172,9 @@ filled with the value of the previous sign-bit.
 (>> 128 u2) ;; Returns 32
 (>> -64 u1) ;; Returns -32
 (>> u128 u2) ;; Returns u32
-(>> u240282366920938463463374607431768211327 u2402823) ;; Returns u0
-(>> -3 u300) ;; Returns -1
+(>> u240282366920938463463374607431768211327 u127) ;; Returns 0
+(>> u123 u2402820) ;; Returns 7 (u123 >> 4)
+(>> -3 u12) ;; Returns -1
 ```
 
 # Related work


### PR DESCRIPTION
This SIP proposes new bitwise operators to be added to Clarity2. It would need to activate with 2.1, as it is a consensus breaking change.

Reference implementation: https://github.com/stacks-network/stacks-blockchain/pull/3389 (in progress)

This change should not hold up code complete for 2.1. If the PR is not approved in time, then it should be saved for the next hard-fork.

In addition to sign off from the Technical CAB for this change, the SIP will also require approval from the Governance CAB to approve the activation strategy.