### PR TITLE
fix: SIP 007 is not a draft

### DIFF
--- a/sips/sip-007/sip-007-stacking-consensus.md
+++ b/sips/sip-007/sip-007-stacking-consensus.md
@@ -92,7 +92,7 @@ converting electricity and computing power to newly minted tokens, nor
 are they staking their cryptocurrency. Rather they use an existing PoW
 cryptocurrency to secure a new, separate blockchain.
 
-This SIP is currently a draft and proposes to change the mining
+This SIP proposes to change the mining
 mechanism of the Stacks blockchain from proof-of-burn (SIP-001) to
 proof-of-transfer.
 


### PR DESCRIPTION
I assume these few words accidentally survived the ratification process, and humbly request to wipe them from the SIP.