### PR TITLE
fix: typo in my last name in Sign-offs

### DIFF
--- a/sips/sip-015/sip-015-network-upgrade.md
+++ b/sips/sip-015/sip-015-network-upgrade.md
@@ -30,8 +30,8 @@ Created: 1 December 2021
 
 License: BSD 2-Clause
 
-Sign-off: Brice Dolby <brice@hiro.so>, Jason Shrader <jason@joinfreedhold.com>, MattyTokenomics
-Jude Nelson <jude@stacks.org>
+Sign-off: Brice Dobry <brice@hiro.so>, Jason Shrader <jason@joinfreedhold.com>,
+          MattyTokenomics, Jude Nelson <jude@stacks.org>
 
 Discussions-To: https://github.com/stacksgov/sips
 

--- a/sips/sip-015/sip-015-network-upgrade.md
+++ b/sips/sip-015/sip-015-network-upgrade.md
@@ -30,7 +30,7 @@ Created: 1 December 2021
 
 License: BSD 2-Clause
 
-Sign-off: Brice Dobry <brice@hiro.so>, Jason Shrader <jason@joinfreedhold.com>,
+Sign-off: Brice Dobry <brice@hiro.so>, Jason Schrader <jason@joinfreehold.com>,
           MattyTokenomics, Jude Nelson <jude@stacks.org>
 
 Discussions-To: https://github.com/stacksgov/sips


### PR DESCRIPTION
Looks like someone mistyped my last name and it didn't get caught. I
also fixed the formatting of this list to look nicer.