### PR TITLE
chore - add wording in the Intro referring to SIP-023 

### DIFF
--- a/sips/sip-022/sip-022-emergency-pox-fix.md
+++ b/sips/sip-022/sip-022-emergency-pox-fix.md
@@ -51,7 +51,11 @@ Stacks 2.3.
 *The following was added after this SIP was accepted, where some version number changes were necessary. The following section addresses these changes **without** changing the ratified text* 
 
 [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md), which was accepted by the required CAB's on May 2nd, 2023 necessitates some changes to this SIP. The changes introduced in [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md) are in response to a bug introduced by the first hard fork, referred to later in this SIP as `Stacks 2.2`. To address the issue, an intermediary version `Stacks 2.3` was created which supercedes the second hard fork as defined here. 
-As a result, the second hard fork defined later in this SIP, `Stacks 2.3` **is now changed to `Stacks 2.4`** due to the intermediary release required as a result of the first hard fork `Stacks 2.2`.
+As a result, the second hard fork defined later in this SIP, `Stacks 2.3` **is now changed to `Stacks 2.4`** due to the intermediary release required as a result of the first hard fork `Stacks 2.2`. 
+
+In addition to the version number change, [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md) also necessitates a change to the peer network version defined later in this SIP as follows:
+* Change the mainnet peer network version bits from `0x18000008` to `0x18000009`. 
+* Change the testnet peer network version bits from `0xfacade08` to `0xfacade09`. 
 
 # Introduction
 

--- a/sips/sip-022/sip-022-emergency-pox-fix.md
+++ b/sips/sip-022/sip-022-emergency-pox-fix.md
@@ -48,6 +48,9 @@ Stacks 2.3.
 
 # Introduction
 
+**Note**: [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md), which was accepted by the required CAB's on May 2nd, 2023 necessitates some changes to this SIP. The changes introduced in [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md) are in response to a bug introduced by the first hard fork here, referred to later in this SIP as `Stacks 2.2`. To address the issue, an intermediary version `Stacks 2.3` was created which supercedes the second hard fork as defined here. 
+As a result, the second hard fork defined later in this SIP, `Stacks 2.3` **is changed to `Stacks 2.4`** due to the intermediary release required as a result of the first hard fork here, `Stacks 2.2`.
+
 [SIP-015](./sips/sip-015/sip-015-network-upgrade.md) proposed a new PoX smart
 contract, `pox-2`, which included a new public function `stack-increase`.  This
 function allows a user to increase the amount of STX locked for PoX while the

--- a/sips/sip-022/sip-022-emergency-pox-fix.md
+++ b/sips/sip-022/sip-022-emergency-pox-fix.md
@@ -46,10 +46,14 @@ This SIP would constitute two consensus-rules version bumps.  During cycle #58, 
 version would be Stacks 2.2.  During and after cycle #59, the system would be
 Stacks 2.3.
 
-# Introduction
+# Addendum
 
-**Note**: [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md), which was accepted by the required CAB's on May 2nd, 2023 necessitates some changes to this SIP. The changes introduced in [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md) are in response to a bug introduced by the first hard fork here, referred to later in this SIP as `Stacks 2.2`. To address the issue, an intermediary version `Stacks 2.3` was created which supercedes the second hard fork as defined here. 
-As a result, the second hard fork defined later in this SIP, `Stacks 2.3` **is changed to `Stacks 2.4`** due to the intermediary release required as a result of the first hard fork here, `Stacks 2.2`.
+*The following was added after this SIP was accepted, where some version number changes were necessary. The following section addresses these changes **without** changing the ratified text* 
+
+[SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md), which was accepted by the required CAB's on May 2nd, 2023 necessitates some changes to this SIP. The changes introduced in [SIP-023](./sips/sip-023/sip-023-emergency-fix-traits.md) are in response to a bug introduced by the first hard fork, referred to later in this SIP as `Stacks 2.2`. To address the issue, an intermediary version `Stacks 2.3` was created which supercedes the second hard fork as defined here. 
+As a result, the second hard fork defined later in this SIP, `Stacks 2.3` **is now changed to `Stacks 2.4`** due to the intermediary release required as a result of the first hard fork `Stacks 2.2`.
+
+# Introduction
 
 [SIP-015](./sips/sip-015/sip-015-network-upgrade.md) proposed a new PoX smart
 contract, `pox-2`, which included a new public function `stack-increase`.  This


### PR DESCRIPTION
Adding a section in the Introduction section detailing that the second hard fork, `2.3` has been changed to `2.4` due to SIP-023. 

no other changes have been made to the approved SIP