### PR TITLE
Multisignature transaction signing order independence

### DIFF
--- a/sips/sip-02X/sip-02X-multisignature-transaction-signing-order-independence.md
+++ b/sips/sip-02X/sip-02X-multisignature-transaction-signing-order-independence.md
@@ -1,0 +1,62 @@
+# Preamble
+
+SIP Number: 02X
+
+Title: Multisignature transaction signing order independence
+
+Author: Vladislav Bespalov <https://github.com/fess-v>
+
+Consideration: Technical
+
+Type: Standard
+
+Status: Draft
+
+Created: 30 April 2023
+
+License: CC0-1.0
+
+Sign-off: -
+
+# Abstract
+
+Multisig transactions work by requiring multiple private keys to sign off on a transaction before it can be executed on the Stacks network. For example, a Stacks wallet may require two out of three private keys to be used in order to authorize a transaction. This means that all three parties involved in the transaction must agree to the terms of the transaction and sign off on it before the funds can be moved. Overall, multisig transactions provide an extra layer of security and control over Stacks transactions, making them a valuable tool for anyone looking to protect their funds.
+
+For such transactions to be really flexible and useful for common users, DAOs, dApps, and companies - it is important for signatures to be order-independent. Current restrictions in signature orders prevent multisignature solutions to emerge.
+
+
+# License and Copyright
+
+This SIP is made available under the terms of the Creative Commons CC0 1.0 Universal license, available at https://creativecommons.org/publicdomain/zero/1.0/
+This SIP’s copyright is held by the Stacks Open Internet Foundation.
+
+# Frontend signature examples
+
+An example of a random signing order can be found below and the full code in this _[issue](https://github.com/hirosystems/stacks.js/issues/1487)_.
+
+```javascript
+  const transaction = await makeUnsignedSTXTokenTransfer({
+      recipient,
+      amount,
+      network,
+      fee,
+      nonce,
+      memo,
+      numSignatures: 2,
+      publicKeys: pubKeyStrings,
+    });
+
+  const signer = new TransactionSigner(transaction);
+  signer.signOrigin(privKeys[2]);
+  signer.appendOrigin(pubKeys[0]);
+  signer.signOrigin(privKeys[1]);
+```
+
+# Related Links
+
+- _[Stacks.js signature order issue](https://github.com/hirosystems/stacks.js/issues/1487)_
+- _[Stacks blockchain signature order issue](https://github.com/stacks-network/stacks-blockchain/issues/2622)_
+
+# Backwards Compatibility
+
+Fully compatible with the previous strict signature order logic

--- a/sips/sip-02X/sip-02X-multisignature-transaction-signing-order-independence.md
+++ b/sips/sip-02X/sip-02X-multisignature-transaction-signing-order-independence.md
@@ -20,10 +20,9 @@ Sign-off: -
 
 # Abstract
 
-Multisig transactions work by requiring multiple private keys to sign off on a transaction before it can be executed on the Stacks network. For example, a Stacks wallet may require two out of three private keys to be used in order to authorize a transaction. This means that all three parties involved in the transaction must agree to the terms of the transaction and sign off on it before the funds can be moved. Overall, multisig transactions provide an extra layer of security and control over Stacks transactions, making them a valuable tool for anyone looking to protect their funds.
+Multisig transactions require multiple private keys to sign off on a transaction before it can be executed on the Stacks network. For example, a Stacks wallet may require the use of two out of three private keys to authorize a transaction. This means that multiple parties involved in the transaction must agree to the terms of the transaction and sign off on it before the funds can be transferred. Multisig transactions offer an additional layer of security and control over Stacks transactions, making them an essential tool for anyone looking to safeguard their funds.
 
-For such transactions to be really flexible and useful for common users, DAOs, dApps, and companies - it is important for signatures to be order-independent. Current restrictions in signature orders prevent multisignature solutions to emerge.
-
+For these transactions to be genuinely flexible and useful for common users, DAOs, dApps, and Stacks ecosystem projects, it is essential for signatures to be order-independent. Current restrictions on signature orders impede the emergence of multisignature solutions. Implementing this feature will result in an easier user experience and increased security when using Multisig wallets within the Stacks ecosystem. This will provide a user-friendly approach for multiple parties to cooperate in a secure environment to participate in Staking STX, Treasury Management for DAOs, and interact with dApps.
 
 # License and Copyright
 


### PR DESCRIPTION
Hey everyone!

We are developing a multisig solution named Asigna (Asigna.io), and we have encountered an important issue. Following the weekly SIP call discussion, we created this SIP to expedite the process. We have attached two GitHub issues for stacks.js (https://github.com/hirosystems/stacks.js/issues/1487) and stacks blockchain (https://github.com/stacks-network/stacks-blockchain/issues/2622). This issue has been labeled as "in the icebox," and we would like to bring it to the attention of the Stacks development team.

Please note that the first commit only contains a draft proposal to initiate discussions and will be updated with more technical information later.

The initial discussion was initiated by the following post on the Stacks forum (https://forum.stacks.org/t/implementing-a-fully-functioning-multisig-wallet-on-stacks/14889).

The issue is in the next_verification method from the MultisigSpendingCondition struct and the verify method for message signatures. Verify goes subsequently over the initial public key array, therefore checks their signatures subsequently, while the next_verification method checks the next signature by wrapping the previous signature into a new hash, which makes it tied to the previous signer.
In my opinion, the solution is to untie this relation and make each sign only the original transaction by each signer and check their signatures accordingly.
The same thing should be implemented in the javascript Stacks.js library for signature construction.
It is also possible to change the order in which signatures are being checked and still wrap the previous signature with a new hash, but I just want to ask if it's really required.

Thanks everyone!