### PR TITLE
Create SIP_TEMPLATE

### DIFF
--- a/sips/SIP_TEMPLATE
+++ b/sips/SIP_TEMPLATE
@@ -1,0 +1,85 @@
+# Preamble
+
+SIP Number: 0xx
+
+Title: xx
+
+Author:
+* Name < email >
+* Name < email >
+
+Status: Draft 
+
+Consideration: Governance, Technical, Economics _(select one or multiple relevant approval committee based on the nature SIP proposed)_
+
+Type: Consensus; Standard, Operation, Meta, Informational _(select one most relevant)_
+
+Layer: Consensus (soft fork), Consensus (hard fork), Peer Services, API/RPC, Traits, Applications _(select one most relevant, if not applicable leave blank)_
+
+Created: 0000-00-00 _(Year-Month-Day)_
+
+License: BSD-2-Clause
+
+Sign-off: _This field will be updated by SIP Repo maintainers._
+
+# Abstract
+
+Insert text.
+
+# License and Copyright
+
+This SIP is made available under the terms of the BSD-2-Clause license,
+available at https://opensource.org/licenses/BSD-2-Clause.  This SIP’s copyright
+is held by the Stacks Open Internet Foundation.
+
+Each SIP must identify at least one acceptable license in its preamble. Source
+code in the SIP can be licensed differently than the text. SIPs whose reference
+implementation(s) touch existing reference implementation(s) must use the same
+license as the existing implementation(s) in order to be considered. Below is a
+list of recommended licenses.
+
+- BSD-2-Clause: OSI-approved BSD 2-clause license
+- BSD-3-Clause: OSI-approved BSD 3-clause license
+- CC0-1.0: Creative Commons CC0 1.0 Universal
+- GNU-All-Permissive: GNU All-Permissive License
+- GPL-2.0+: GNU General Public License (GPL), version 2 or newer
+- LGPL-2.1+: GNU Lesser General Public License (LGPL), version 2.1 or newer
+
+# Introduction
+
+Insert text.
+Add Header 2 ## and Header 3 ### and Header 4 #### as necessary
+
+# Specification
+
+Insert text.
+Add Header 2 ## and Header 3 ### as necessary
+
+# Backwards Compatibility
+
+Insert text.
+
+# Related Work
+
+Insert text.
+
+# Activation
+
+Insert text.
+Add Header 2 ## and Header 3 ### and Header 4 #### as necessary
+
+# Activation Status
+
+_This section will be updated by SIP Repo maintainers._
+
+# Reference Implementation
+
+Insert text.
+
+# References
+
+[1]
+
+[2]
+
+[3]


### PR DESCRIPTION
Starting a NEW SIP Template for easy of SIP Author to start somewhere which will output consistent formatting thereby saving time spent by SIP Editors and/or core devs.

**Support needed to refine instruction:**
* Wording the License field part better + the License and Copyright Section. 

**Open questions:**
1. In BIP process, they recently changed "created" field in Preamble to "Assigned" https://github.com/bitcoin/bips/pull/1970  we could use this opportunity to update to align. I asked the BIP Editor Jon, his reasoning was "I suppose it's simply to provide a date for people to see when a BIP was launched. A number assignment seems to be the most interesting date for people, more than when the draft PR was opened or merged."

cc: @wileyj @jcnelson @314159265359879 @rafaelcr 