### PR TITLE
Adding technical cab minutes for SIP-033

### DIFF
--- a/considerations/minutes/technical-cab/2025-10-06-sip-033.md
+++ b/considerations/minutes/technical-cab/2025-10-06-sip-033.md
@@ -1,0 +1,53 @@
+# Technical CAB Minutes
+
+## Meeting Information
+
+**Location:** Discord (async)
+
+**Recorded:** No
+
+**Date:**
+
+- Oct 6th, 2025
+
+**Time:** n/a
+
+**Attendees:**
+
+- Aaron Blankstein
+- Brice Dobry
+- j2p2
+- Friedger
+- Jesse Wiley
+- Vlad
+- Radu
+- Setzeus
+
+**Topic(s):**
+
+- [Clarity 4: high-demand new builtins](https://github.com/stacksgov/sips/pull/218)
+
+**Materials**:
+
+- [Clarity 4: high-demand new builtins](https://github.com/stacksgov/sips/pull/218)
+- https://forum.stacks.org/t/clarity-4-proposal-new-builtins-for-vital-ecosystem-projects/18266
+
+## 2025-10-06 Meeting Notes
+
+The Technical CAB discussed SIP-023 and the supporting materials, and concluded that this hard fork is necessary to support the ecosystem.
+
+## Vote Outcome(s)
+
+| Name             | Vote    |
+| ---------------- | ------- |
+| Aaron Blankstein | abstain |
+| j2p2             | yes     |
+| Friedger         | abstain |
+| Jesse Wiley      | yes     |
+| Vlad             | abstain |
+| Radu             | yes     |
+| Setzeus          | yes     |
+
+_Note_ Brice Dobry is the author of SIP-033, as such no vote was tallied for him.
+
+The Technical CAB approves SIP-033 with 4 yes votes, where 3 members abstained and 1 vote was discarded due to authorship.


### PR DESCRIPTION
re: https://github.com/stacksgov/sips/pull/218

Adding minutes and vote totals for SIP-033 technical CAB. 


Note: unsure why the commit shows as "unverified"- on the fork, the correct key is shown. 
<img width="625" height="196" alt="Screenshot 2025-10-06 at 15 09 33" src="https://github.com/user-attachments/assets/6753ae8e-a22a-436f-ae82-ce1f4a7d1ce6" />
